### PR TITLE
Added RANDOM_STATE to train_test_split

### DIFF
--- a/ml-debugging/src/exercise.py
+++ b/ml-debugging/src/exercise.py
@@ -63,7 +63,7 @@ def main() -> None:
     y = titanic_data[target]
 
     # Split the data into training and testing sets
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=RANDOM_STATE)
 
     # Train a Random Forest classifier
     print("Training a Random Forest classifier...")


### PR DESCRIPTION
A bug was appearing due to a non-numerical value in train.csv. This bug can be avoided, whilst leaving the error in the data by setting the `random_state` in the `train_test_split` function. This ensures that the non-numerical value appears in the train set.